### PR TITLE
Issue #35: Add script to add team to repos

### DIFF
--- a/github-management-script/add-team-to-repos.md
+++ b/github-management-script/add-team-to-repos.md
@@ -1,0 +1,53 @@
+# GitHub Team Addition Script
+
+This script is designed to automate the process of adding a specific team to all
+repositories within a specified GitHub organization. It dynamically assigns
+teams to repositories based on the repository naming conventions and ensures
+that an administrative team is added to each repository.
+
+## Functionality
+
+- **Automated Team Assignment:** Automatically adds a specified team to all
+  repositories within a given GitHub organization.
+- **Dynamic Team Assignment:** The script assigns teams (`backend`, `frontend`,
+  `db`) dynamically based on the naming convention of the repositories.
+- **Admin Team Enforcement:** Ensures that an administrative team is added to
+  every repository, regardless of its naming convention.
+
+## Requirements
+
+- **GitHub Personal Access Token (PAT):** You must have a GitHub Personal Access
+  Token with appropriate permissions to add teams to repositories.
+
+## Usage
+
+1. **Prepare the Script:**
+   - Ensure you have Node.js installed on your system.
+   - Clone or download the script to your local machine.
+
+2. **Configuration:**
+   - Open the script in your text editor.
+   - Fill in the `GITHUB_ORG`, `TEAM_PERMISSION` and
+     `ADMIN_TEAM_SLUG` variables with the appropriate values for your GitHub
+     organization and teams.
+
+3. **Run the Script:**
+   - Open your terminal and navigate to the directory containing the script.
+   - Execute the script by running:
+
+     ```sh
+     ./add-team-to-repos.sh
+     ```
+
+   - When prompted, enter your GitHub Personal Access Token. This token is used
+     to authenticate requests to the GitHub API.
+
+4. **Operation:**
+   - The script fetches all repositories from the specified organization.
+   - It iterates over each repository, adding the specified team, and logs the
+     progress in the console.
+   - If the repository name includes specific keywords (e.g., 'backend',
+     'frontend', 'db'), it assigns different teams based on these keywords.
+   - The script also ensures that the administrative team is added to every
+     repository, maintaining a consistent level of access control across all
+     organizational repositories.

--- a/github-management-script/add-team-to-repos.sh
+++ b/github-management-script/add-team-to-repos.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+ORG_NAME='ai-cfia'
+TEAM_PERMISSION='push' # 'pull' or 'push' or 'admin'
+ADMIN_TEAM_SLUG='devops'
+
+echo "Please enter your GitHub access token:"
+read -r GITHUB_TOKEN
+
+add_team_to_repo() {
+    local team_slug=$1
+    local org=$2
+    local repo=$3
+    local permission=$4
+    local owner=$5
+
+    curl -s -X PUT -H "Authorization: token ${GITHUB_TOKEN}" \
+        "https://api.github.com/orgs/${org}/teams/${team_slug}/repos/${owner}/${repo}" \
+        -d "{\"permission\":\"${permission}\"}"
+}
+
+PAGE=1
+PER_PAGE=100
+
+while :; do
+  API_URL="https://api.github.com/orgs/${ORG_NAME}/repos?type=public&per_page=${PER_PAGE}&page=${PAGE}"
+
+  RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                    "${API_URL}")
+
+  REPOS=$(echo "${RESPONSE}" | jq -r '.[].full_name')
+  
+  if [[ -z "${REPOS}" ]]; then
+    break
+  fi
+
+  for REPO in ${REPOS}; do
+    if [[ "${REPO}" == *backend* ]]; then
+        TEAM_SLUG='backend'
+    elif [[ "${REPO}" == *frontend* ]]; then
+        TEAM_SLUG='frontend'
+    elif [[ "${REPO}" == *db* ]]; then
+        TEAM_SLUG='db'
+    else
+        TEAM_SLUG='devops'
+    fi
+
+    echo "Adding team \"${TEAM_SLUG}\" to repo \"${REPO}\" with permission \"${TEAM_PERMISSION}\""
+    add_team_to_repo "${TEAM_SLUG}" "${ORG_NAME}" "${REPO}" "${TEAM_PERMISSION}"
+
+    if [[ "${TEAM_SLUG}" != "${ADMIN_TEAM_SLUG}" ]]; then
+        echo "Adding team \"${ADMIN_TEAM_SLUG}\" to repo \"${REPO}\" with permission \"${TEAM_PERMISSION}\""
+        add_team_to_repo "${ADMIN_TEAM_SLUG}" "${ORG_NAME}" "${REPO}" "${TEAM_PERMISSION}"
+    else
+        echo "... Skipped adding team \"${ADMIN_TEAM_SLUG}\" as it is the same as \"${TEAM_SLUG}\""
+    fi
+  done
+
+  ((PAGE++))
+done


### PR DESCRIPTION
This script allows to add devops team with required permissions to repos allowing codeowners files to be valid. It also adds frontend, backend and db team to their respective repos. This script was already executed in order to have valid codeowners file configuration. 